### PR TITLE
[PR] Use new `register_rest_field` vs deprecated `register_api_field`

### DIFF
--- a/wsu-people-directory.php
+++ b/wsu-people-directory.php
@@ -1240,7 +1240,7 @@ class WSUWP_People_Directory {
 			'schema' => null,
 		);
 		foreach( $this->rest_response_fields as $field_name => $value ) {
-			register_api_field( $this->personnel_content_type, $field_name, $args );
+			register_rest_field( $this->personnel_content_type, $field_name, $args );
 		}
 	}
 


### PR DESCRIPTION
The REST API v2beta9 deprecates `register_api_field` in favor of
`register_rest_field`.