### PR TITLE
[PR] Add support for REST API requests by wsu_nid

### DIFF
--- a/wsu-people-directory.php
+++ b/wsu-people-directory.php
@@ -257,8 +257,10 @@ class WSUWP_People_Directory {
 		// Modify taxonomy columns on "All Profiles" page.
 		add_filter( 'manage_taxonomies_for_wsuwp_people_profile_columns', array( $this, 'wsuwp_people_profile_columns' ) );
 
-		// Allow queries by meta data.
-		add_filter( 'rest_query_vars', array( $this, 'rest_query_vars' ) );
+		// Allow REST get_items() queries by additional data.
+		add_action( 'init', array( $this, 'register_wsu_nid_query_var' ) );
+		add_filter( "rest_{$this->personnel_content_type}_query", array( $this, 'rest_query_vars' ), 10, 2 );
+		add_action( 'pre_get_posts', array( $this, 'handle_wsu_nid_query_var' ) );
 
 		// Register custom fields with the REST API.
 		add_action( 'rest_api_init', array( $this, 'register_api_fields' ) );
@@ -1221,11 +1223,44 @@ class WSUWP_People_Directory {
 	}
 
 	/**
-	 * Allow queries by meta data.
+	 * Registers the wsu_nid parameter.
+	 *
+	 * @since 0.2.2
 	 */
-	public function rest_query_vars( $valid_vars ) {
-		$valid_vars = array_merge( $valid_vars, array( 'meta_key', 'meta_value' ) );
+	public function register_wsu_nid_query_var() {
+		global $wp;
+		$wp->add_query_var( 'wsu_nid' );
+	}
+
+	/**
+	 * Retrieves a passed wsu_nid with a REST request and adds to the query vars.
+	 *
+	 * @since 0.2.2
+	 *
+	 * @param array           $valid_vars
+	 * @param WP_REST_Request $request
+	 *
+	 * @return array
+	 */
+	public function rest_query_vars( $valid_vars, $request ) {
+		$valid_vars['wsu_nid'] = $request->get_param( 'wsu_nid' );
+
 		return $valid_vars;
+	}
+
+	/**
+	 * Sets a meta query for WSU NID when the wsu_nid parameters is included as
+	 * part of a query.
+	 *
+	 * @since 0.2.2
+	 *
+	 * @param WP_Query $query
+	 */
+	public function handle_wsu_nid_query_var( $query ) {
+		if ( isset( $query->query['wsu_nid'] ) && $query->query['wsu_nid'] ) {
+			$query->set( 'meta_key', '_wsuwp_profile_ad_nid' );
+			$query->set( 'meta_value', sanitize_text_field( $query->query['wsu_nid'] ) );
+		}
 	}
 
 	/**


### PR DESCRIPTION
Previously, we supported the open querying of `meta_key` and `meta_value`. In the release of the REST API in WordPress 4.7, the filter allowing this changed a bit, forcing us to adjust.

Rather than duplicate the behavior, this gives us the opportunity to restrict things a bit and only allow queries by a whitelist of query vars.

This adds support for the `wsu_nid` query parameter to REST API requests on the people post type.

Example: `https://people.wsu.edu/wp-json/wp/v2/people?wsu_nid=jeremy.felt`