### PR TITLE
[PR] Handle invalid REST API request when storing profiles on a directory

### DIFF
--- a/phpcs.ruleset.xml
+++ b/phpcs.ruleset.xml
@@ -5,5 +5,6 @@
     <rule ref="WordPress-Extra">
         <exclude name="WordPress.NamingConventions.ValidFunctionName" />
         <exclude name="Generic.PHP.DisallowAlternativePHPTags.MaybeASPShortOpenTagFound" />
+        <exclude name="Squiz.Commenting.LongConditionClosingComment" />
     </rule>
 </ruleset>


### PR DESCRIPTION
I ran into an issue where a REST API request for my NID failed, but the NID was still saved to the directory page. This prevented the profile from being stored on the local site, which confused things when the directory page was displayed.

We can work around this by only storing NIDs that come back with successful REST API data or have already been created as profiles on the local site.