### PR TITLE
[PR] Ensure `$photos` is an array before treating it as one

### DIFF
--- a/includes/class-wsuwp-people-directory.php
+++ b/includes/class-wsuwp-people-directory.php
@@ -14,7 +14,7 @@ class WSUWP_People_Directory {
 	 *
 	 * @var string
 	 */
-	public static $version = '0.3.10';
+	public static $version = '0.3.11';
 
 	/**
 	 * Maintain and return the one instance. Initiate hooks when called the first time.

--- a/includes/class-wsuwp-people-post-type.php
+++ b/includes/class-wsuwp-people-post-type.php
@@ -576,6 +576,7 @@ class WSUWP_People_Post_Type {
 				}
 			}
 		} elseif ( has_post_thumbnail() ) {
+			$photos = array(); // An array is expected further down.
 			$photo_url = get_the_post_thumbnail_url();
 		}
 		?>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "wsu-people-directory",
-  "version": "0.3.9",
+  "version": "0.3.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -376,7 +376,7 @@
         "glob": {
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
           "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
@@ -2309,7 +2309,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "dev": true,
       "requires": {
         "brace-expansion": "1.1.8"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wsu-people-directory",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "repository": {
     "type": "git",
     "url": "https://github.com/washingtonstateuniversity/wsu-people-directory"

--- a/wsu-people-directory.php
+++ b/wsu-people-directory.php
@@ -4,7 +4,7 @@ Plugin Name: WSU People Directory
 Plugin URI: https://web.wsu.edu/wordpress/plugins/wsu-people-directory/
 Description: A plugin to maintain a central directory of people.
 Author:	washingtonstateuniversity, CAHNRS, philcable, danialbleile, jeremyfelt
-Version: 0.3.10
+Version: 0.3.11
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 */


### PR DESCRIPTION
Fixes an error in PHP 7.1:

```
PHP Fatal error:  Uncaught Error: [] operator not supported for strings
wsu-people-directory/includes/class-wsuwp-people-post-type.php:630
```