### PR TITLE
Fix trailing slash on profile view

### DIFF
--- a/includes/class-wsuwp-people-directory-page-template.php
+++ b/includes/class-wsuwp-people-directory-page-template.php
@@ -945,11 +945,16 @@ class WSUWP_People_Directory_Page_Template {
 				if ( in_array( 'location', $filters, true ) ) {
 					$locations = wp_get_post_terms( get_the_ID(), 'wsuwp_university_location', $get_terms_args );
 
+					$locations = ( is_array( $locations ) ) ? $locations : array();
+
 					$local_data['locations'] = array_unique( array_merge( $local_data['locations'], $locations ) );
 				}
 
 				if ( in_array( 'org', $filters, true ) ) {
 					$orgs = wp_get_post_terms( get_the_ID(), 'wsuwp_university_org', $get_terms_args );
+
+					$orgs = ( is_array( $orgs ) ) ? $orgs : array();
+
 					$local_data['orgs'] = array_unique( array_merge( $local_data['orgs'], $orgs ) );
 				}
 			}

--- a/includes/class-wsuwp-people-directory.php
+++ b/includes/class-wsuwp-people-directory.php
@@ -14,7 +14,7 @@ class WSUWP_People_Directory {
 	 *
 	 * @var string
 	 */
-	public static $version = '0.3.15';
+	public static $version = '0.3.17';
 
 	/**
 	 * Maintain and return the one instance. Initiate hooks when called the first time.

--- a/includes/class-wsuwp-person-display.php
+++ b/includes/class-wsuwp-person-display.php
@@ -393,7 +393,8 @@ class WSUWP_Person_Display {
 		if ( false !== apply_filters( 'wsuwp_people_default_rewrite_slug', false ) ) {
 			$link = get_the_permalink( $local_post_id );
 		} elseif ( 'if_bio' === $options['link']['when'] && '' !== $data['about'] || 'yes' === $options['link']['when'] ) {
-			$link = trailingslashit( $options['link']['base_url'] . $local_post->post_name );
+			$base_link = trailingslashit( $options['link']['base_url'] );
+			$link = trailingslashit( $base_link . $local_post->post_name );
 		}
 
 		// Set up directory page-specific content display options.

--- a/wsu-people-directory.php
+++ b/wsu-people-directory.php
@@ -4,7 +4,7 @@ Plugin Name: WSU People Directory
 Plugin URI: https://web.wsu.edu/wordpress/plugins/wsu-people-directory/
 Description: A plugin to maintain a central directory of people.
 Author:	washingtonstateuniversity, CAHNRS, philcable, danialbleile, jeremyfelt
-Version: 0.3.16
+Version: 0.3.17
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 */


### PR DESCRIPTION
Update profile links to force trailing slash after base url

## Added
- Added check for array on class-wsuwp-people-directory-page-template.php for both $locations and $orgs to fix merge array (not an array) warning.
- Added tralingslashit to base url in class-wsuwp-person-display.php to force trailing slash.